### PR TITLE
chromium: change chromium container tag

### DIFF
--- a/chromium/docker-compose-apalis-imx6.yml
+++ b/chromium/docker-compose-apalis-imx6.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-apalis-imx8.yml
+++ b/chromium/docker-compose-apalis-imx8.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-colibri-imx6.yml
+++ b/chromium/docker-compose-colibri-imx6.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-colibri-imx6ull.yml
+++ b/chromium/docker-compose-colibri-imx6ull.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-colibri-imx7.yml
+++ b/chromium/docker-compose-colibri-imx7.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-colibri-imx8x.yml
+++ b/chromium/docker-compose-colibri-imx8x.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-verdin-imx8mm.yml
+++ b/chromium/docker-compose-verdin-imx8mm.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb

--- a/chromium/docker-compose-verdin-imx8mp.yml
+++ b/chromium/docker-compose-verdin-imx8mp.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   chromium:
-    image: torizon/chromium:3
+    image: torizon/chromium:3.4
     security_opt:
       - seccomp:unconfined
     shm_size: 256mb


### PR DESCRIPTION
Change the dockerhub container tag for chromium from 3 to 3.4

The reason for that is that the tag 3 is constantly updated, so 3.4 should be more stable