### PR TITLE
Canonicalize the docker composes

### DIFF
--- a/chromium/docker-compose-apalis-imx6.yml
+++ b/chromium/docker-compose-apalis-imx6.yml
@@ -1,54 +1,45 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/dri
-        target: /dev/dri
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/dri
+      target: /dev/dri
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-apalis-imx8.yml
+++ b/chromium/docker-compose-apalis-imx8.yml
@@ -1,58 +1,48 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/
-        target: /dev/
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/
+      target: /dev/
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-colibri-imx6.yml
+++ b/chromium/docker-compose-colibri-imx6.yml
@@ -1,54 +1,45 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/dri
-        target: /dev/dri
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/dri
+      target: /dev/dri
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-colibri-imx6ull.yml
+++ b/chromium/docker-compose-colibri-imx6ull.yml
@@ -1,57 +1,48 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/
-        target: /dev/
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/
+      target: /dev/
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
-    ipc: host
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
     cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
+    - CAP_SYS_TTY_CONFIG
     command:
-      - --tty=/dev/tty7
-      - --
-      - --use-pixman
+    - --tty=/dev/tty7
+    - --
+    - --use-pixman
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    ipc: host
+    network_mode: host
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-colibri-imx7.yml
+++ b/chromium/docker-compose-colibri-imx7.yml
@@ -1,57 +1,48 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/
-        target: /dev/
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/
+      target: /dev/
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
-    ipc: host
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
     cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
+    - CAP_SYS_TTY_CONFIG
     command:
-      - --tty=/dev/tty7
-      - --
-      - --use-pixman
+    - --tty=/dev/tty7
+    - --
+    - --use-pixman
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    ipc: host
+    network_mode: host
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-colibri-imx8x.yml
+++ b/chromium/docker-compose-colibri-imx8x.yml
@@ -1,58 +1,48 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/
-        target: /dev/
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/
+      target: /dev/
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-verdin-am62.yml
+++ b/chromium/docker-compose-verdin-am62.yml
@@ -1,54 +1,45 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium-am62:3
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium-am62@sha256:bb633a994129357eda8fef826ae614bbeadf99a8f9013ae1f2481c327c247433
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/dri
-        target: /dev/dri
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/dri
+      target: /dev/dri
+      type: bind
   weston:
-    image: torizon/weston-am62:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-verdin-imx8mm.yml
+++ b/chromium/docker-compose-verdin-imx8mm.yml
@@ -1,58 +1,48 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/
-        target: /dev/
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/
+      target: /dev/
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/chromium/docker-compose-verdin-imx8mp.yml
+++ b/chromium/docker-compose-verdin-imx8mp.yml
@@ -1,58 +1,48 @@
-version: "3"
 services:
   chromium:
-    image: torizon/chromium:3.4
+    command:
+    - --virtual-keyboard
+    - https://www.toradex.com
+    depends_on:
+    - weston
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     security_opt:
-      - seccomp:unconfined
+    - seccomp:unconfined
     shm_size: 256mb
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /var/run/dbus
-        target: /var/run/dbus
-      - type: bind
-        source: /dev/
-        target: /dev/
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --virtual-keyboard
-      - https://www.toradex.com
-    depends_on: [
-      weston
-    ]
-
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /var/run/dbus
+      target: /var/run/dbus
+      type: bind
+    - source: /dev/
+      target: /dev/
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/codesys/docker-compose-apalis-imx6.yml
+++ b/codesys/docker-compose-apalis-imx6.yml
@@ -1,74 +1,72 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3.4
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/dri:/dev/dri
-    device_cgroup_rules:
-      - 'c 226:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/dri:/dev/dri
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm32:4.13.0.0
+    image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-apalis-imx8.yml
+++ b/codesys/docker-compose-apalis-imx8.yml
@@ -1,75 +1,73 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston-vivante:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    command: --developer
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/galcore:/dev/galcore
-    device_cgroup_rules:
-      - 'c 199:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/galcore:/dev/galcore
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm64:4.13.0.0
+    image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm64:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    command: --developer
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-colibri-imx6.yml
+++ b/codesys/docker-compose-colibri-imx6.yml
@@ -1,74 +1,72 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3.4
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/dri:/dev/dri
-    device_cgroup_rules:
-      - 'c 226:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/dri:/dev/dri
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm32:4.13.0.0
+    image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-colibri-imx6ull.yml
+++ b/codesys/docker-compose-colibri-imx6ull.yml
@@ -1,74 +1,72 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3.4
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/dri:/dev/dri
-    device_cgroup_rules:
-      - 'c 226:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/dri:/dev/dri
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm32:4.13.0.0
+    image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-colibri-imx7.yml
+++ b/codesys/docker-compose-colibri-imx7.yml
@@ -1,74 +1,72 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3.4
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/dri:/dev/dri
-    device_cgroup_rules:
-      - 'c 226:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 226:* rmw
+    image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/dri:/dev/dri
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm32:4.13.0.0
+    image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-colibri-imx8x.yml
+++ b/codesys/docker-compose-colibri-imx8x.yml
@@ -1,75 +1,73 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston-vivante:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    command: --developer
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/galcore:/dev/galcore
-    device_cgroup_rules:
-      - 'c 199:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/galcore:/dev/galcore
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm64:4.13.0.0
+    image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm64:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    command: --developer
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-verdin-am62.yml
+++ b/codesys/docker-compose-verdin-am62.yml
@@ -1,75 +1,73 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston-am62:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    command: --developer
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium-am62:3
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/galcore:/dev/galcore
-    device_cgroup_rules:
-      - 'c 199:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium-am62@sha256:bb633a994129357eda8fef826ae614bbeadf99a8f9013ae1f2481c327c247433
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/galcore:/dev/galcore
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm64:4.13.0.0
+    image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm64:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    command: --developer
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-verdin-imx8mm.yml
+++ b/codesys/docker-compose-verdin-imx8mm.yml
@@ -1,75 +1,73 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston-vivante:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    command: --developer
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/galcore:/dev/galcore
-    device_cgroup_rules:
-      - 'c 199:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/galcore:/dev/galcore
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm64:4.13.0.0
+    image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm64:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    command: --developer
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/codesys/docker-compose-verdin-imx8mp.yml
+++ b/codesys/docker-compose-verdin-imx8mp.yml
@@ -1,75 +1,73 @@
-version: '3.8'
-
 services:
-  weston:
-    image: torizon/weston-vivante:3
-    environment:
-      - ACCEPT_FSL_EULA=1
-    network_mode: host
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    volumes:
-      - /dev:/dev
-      - /tmp:/tmp
-      - /run/udev/:/run/udev/
-    device_cgroup_rules:
-      - 'c 4:* rmw'
-      - 'c 13:* rmw'
-      - 'c 199:* rmw'
-      - 'c 226:* rmw'
-    command: --developer
-    restart: unless-stopped
-
   chromium:
-    image: torizon/chromium:3
-    network_mode: host
-    depends_on: ["codesys-setup"]
-    volumes:
-      - /tmp:/tmp
-      - /var/run/dbus:/var/run/dbus
-      - /dev/galcore:/dev/galcore
-    device_cgroup_rules:
-      - 'c 199:* rmw'
-    security_opt:
-      - seccomp=unconfined
-    shm_size: '256mb'
     command: --virtual-keyboard http://localhost:80
+    depends_on:
+    - codesys-setup
+    device_cgroup_rules:
+    - c 199:* rmw
+    image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
+    network_mode: host
     restart: unless-stopped
-
+    security_opt:
+    - seccomp=unconfined
+    shm_size: 256mb
+    volumes:
+    - /tmp:/tmp
+    - /var/run/dbus:/var/run/dbus
+    - /dev/galcore:/dev/galcore
+  codesys:
+    cap_add:
+    - CHOWN
+    - IPC_LOCK
+    - KILL
+    - NET_ADMIN
+    - NET_BIND_SERVICE
+    - NET_BROADCAST
+    - NET_RAW
+    - SETFCAP
+    - SETPCAP
+    - SYS_ADMIN
+    - SYS_MODULE
+    - SYS_NICE
+    - SYS_PTRACE
+    - SYS_RAWIO
+    - SYS_RESOURCE
+    - SYS_TIME
+    command: cat /conf/codesyscontrol/started
+    depends_on:
+    - codesys-setup
+    image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+    - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
+    - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
+    - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
+    - /var/run/codesysextension/:/var/run/codesysextension/
   codesys-setup:
-    image: toradexdemos/codesys_demo_arm64:4.13.0.0
+    image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
     privileged: true
-    volumes:
-      - /tmp/dockerMount:/dockerMount_copy
     restart: unless-stopped
-
-  codesys:
-    image: toradexdemos/codesyscontrol_virtuallinuxarm64:4.13.0.0
     volumes:
-      - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
-      - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
-      - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
-      - /var/run/codesysextension/:/var/run/codesysextension/
-    depends_on: ["codesys-setup"]
-    network_mode: host
+    - /tmp/dockerMount:/dockerMount_copy
+  weston:
     cap_add:
-      - CHOWN
-      - IPC_LOCK
-      - KILL
-      - NET_ADMIN
-      - NET_BIND_SERVICE
-      - NET_BROADCAST
-      - NET_RAW
-      - SETFCAP
-      - SETPCAP
-      - SYS_ADMIN
-      - SYS_MODULE
-      - SYS_NICE
-      - SYS_PTRACE
-      - SYS_RAWIO
-      - SYS_RESOURCE
-      - SYS_TIME
+    - CAP_SYS_TTY_CONFIG
+    command: --developer
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    environment:
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
+    network_mode: host
     restart: unless-stopped
-    command: cat /conf/codesyscontrol/started
+    volumes:
+    - /dev:/dev
+    - /tmp:/tmp
+    - /run/udev/:/run/udev/
+version: '3.8'

--- a/node-red/docker-compose.yml
+++ b/node-red/docker-compose.yml
@@ -1,19 +1,16 @@
-version: "3.9"
-
+networks:
+  node-red-net: null
 services:
   node-red:
-    image: nodered/node-red:3.1.3
     environment:
-      - TZ=Europe/Amsterdam
-    ports:
-      - "1880:1880"
+    - TZ=Europe/Amsterdam
+    image: nodered/node-red@sha256:75e48924159f6c6bf4221017069a8b496cab8d0b21d3d0b1fcaf058af8294865
     networks:
-      - node-red-net
+    - node-red-net
+    ports:
+    - 1880:1880
     volumes:
-      - node-red-data:/data
-
+    - node-red-data:/data
+version: '3.9'
 volumes:
-  node-red-data:
-
-networks:
-  node-red-net:
+  node-red-data: null

--- a/qt/docker-compose-apalis-imx6.yml
+++ b/qt/docker-compose-apalis-imx6.yml
@@ -1,52 +1,40 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-apalis-imx8.yml
+++ b/qt/docker-compose-apalis-imx8.yml
@@ -1,56 +1,43 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template-vivante:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-colibri-imx6.yml
+++ b/qt/docker-compose-colibri-imx6.yml
@@ -1,52 +1,40 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-colibri-imx6ull.yml
+++ b/qt/docker-compose-colibri-imx6ull.yml
@@ -1,55 +1,43 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
-    ipc: host
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
     cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
+    - CAP_SYS_TTY_CONFIG
     command:
-      - --tty=/dev/tty7
-      - --
-      - --use-pixman
+    - --tty=/dev/tty7
+    - --
+    - --use-pixman
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    ipc: host
+    network_mode: host
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-colibri-imx7.yml
+++ b/qt/docker-compose-colibri-imx7.yml
@@ -1,55 +1,43 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
-    ipc: host
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
     cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
+    - CAP_SYS_TTY_CONFIG
     command:
-      - --tty=/dev/tty7
-      - --
-      - --use-pixman
+    - --tty=/dev/tty7
+    - --
+    - --use-pixman
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    ipc: host
+    network_mode: host
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-colibri-imx8x.yml
+++ b/qt/docker-compose-colibri-imx8x.yml
@@ -1,56 +1,43 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template-vivante:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-verdin-am62.yml
+++ b/qt/docker-compose-verdin-am62.yml
@@ -1,52 +1,40 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template-am62:3.0.1
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template-am62@sha256:c6621cb326d468ad4a48e5c9296b04892ffbd291a05ac3c82940ce8b02da2a25
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston-am62:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-verdin-imx8mm.yml
+++ b/qt/docker-compose-verdin-imx8mm.yml
@@ -1,56 +1,43 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template-vivante:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/qt/docker-compose-verdin-imx8mp.yml
+++ b/qt/docker-compose-verdin-imx8mp.yml
@@ -1,56 +1,43 @@
-version: "3.9"
 services:
   app:
-    image: lucastor/cppqml-template-vivante:3.2.0
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-    # Add device access rights through cgroup...
+    depends_on:
+    - weston
     device_cgroup_rules:
-      # ... for tty0
-      - "c 4:0 rmw"
-      # ... for tty7
-      - "c 4:7 rmw"
-      # ... for /dev/input devices
-      - "c 13:* rmw"
-      - "c 199:* rmw"
-      # ... for /dev/dri devices
-      - "c 226:* rmw"
-    depends_on: [
-      weston
-    ]
-
+    - c 4:0 rmw
+    - c 4:7 rmw
+    - c 13:* rmw
+    - c 199:* rmw
+    - c 226:* rmw
+    image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3.9'

--- a/weston/docker-compose-apalis-imx6.yml
+++ b/weston/docker-compose-apalis-imx6.yml
@@ -1,28 +1,23 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-apalis-imx8.yml
+++ b/weston/docker-compose-apalis-imx8.yml
@@ -1,32 +1,26 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-colibri-imx6.yml
+++ b/weston/docker-compose-colibri-imx6.yml
@@ -1,28 +1,23 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-colibri-imx6ull.yml
+++ b/weston/docker-compose-colibri-imx6ull.yml
@@ -1,31 +1,26 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
-    ipc: host
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
     cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
+    - CAP_SYS_TTY_CONFIG
     command:
-      - --tty=/dev/tty7
-      - --
-      - --use-pixman
+    - --tty=/dev/tty7
+    - --
+    - --use-pixman
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    ipc: host
+    network_mode: host
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-colibri-imx7.yml
+++ b/weston/docker-compose-colibri-imx7.yml
@@ -1,31 +1,26 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston:3
-    # Required to get udev events from host udevd via netlink
-    network_mode: host
-    ipc: host
-    volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
     cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
+    - CAP_SYS_TTY_CONFIG
     command:
-      - --tty=/dev/tty7
-      - --
-      - --use-pixman
+    - --tty=/dev/tty7
+    - --
+    - --use-pixman
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
+    ipc: host
+    network_mode: host
+    volumes:
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-colibri-imx8x.yml
+++ b/weston/docker-compose-colibri-imx8x.yml
@@ -1,32 +1,26 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-verdin-am62.yml
+++ b/weston/docker-compose-verdin-am62.yml
@@ -1,28 +1,23 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston-am62:3
-    # Required to get udev events from host udevd via netlink
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/dri devices
-      - 'c 226:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-verdin-imx8mm.yml
+++ b/weston/docker-compose-verdin-imx8mm.yml
@@ -1,32 +1,26 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'

--- a/weston/docker-compose-verdin-imx8mp.yml
+++ b/weston/docker-compose-verdin-imx8mp.yml
@@ -1,32 +1,26 @@
-version: "3"
 services:
   weston:
-    image: torizon/weston-vivante:3
+    cap_add:
+    - CAP_SYS_TTY_CONFIG
+    command:
+    - --tty=/dev/tty7
+    device_cgroup_rules:
+    - c 4:* rmw
+    - c 13:* rmw
+    - c 226:* rmw
+    - c 199:* rmw
     environment:
-      - ACCEPT_FSL_EULA=1
-    # Required to get udev events from host udevd via netlink
+    - ACCEPT_FSL_EULA=1
+    image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
     volumes:
-      - type: bind
-        source: /tmp
-        target: /tmp
-      - type: bind
-        source: /dev
-        target: /dev
-      - type: bind
-        source: /run/udev
-        target: /run/udev
-    cap_add:
-      - CAP_SYS_TTY_CONFIG
-    # Add device access rights through cgroup...
-    device_cgroup_rules:
-      # ... for tty0
-      - 'c 4:* rmw'
-      # ... for /dev/input devices
-      - 'c 13:* rmw'
-      # ... for /dev/galcore devices
-      - 'c 226:* rmw'
-      # ... for /dev/dri devices
-      - 'c 199:* rmw'
-    command:
-      - --tty=/dev/tty7
+    - source: /tmp
+      target: /tmp
+      type: bind
+    - source: /dev
+      target: /dev
+      type: bind
+    - source: /run/udev
+      target: /run/udev
+      type: bind
+version: '3'


### PR DESCRIPTION
To use the evaluation apps with a lockbox, 
it requires that the docker-composes are in canonicalized format