### PR TITLE
Add explicit platform declarations for module-specific apps.

### DIFF
--- a/chromium/docker-compose-apalis-imx6.yml
+++ b/chromium/docker-compose-apalis-imx6.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm/v7
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/dri
       target: /dev/dri
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -33,6 +33,7 @@ services:
     - c 226:* rmw
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -43,5 +44,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-apalis-imx6.yml
+++ b/chromium/docker-compose-apalis-imx6.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/dri
       target: /dev/dri
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -42,4 +43,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-apalis-imx8.yml
+++ b/chromium/docker-compose-apalis-imx8.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 199:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm64
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -36,6 +36,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -46,5 +47,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-apalis-imx8.yml
+++ b/chromium/docker-compose-apalis-imx8.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -45,4 +46,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-colibri-imx6.yml
+++ b/chromium/docker-compose-colibri-imx6.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm/v7
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/dri
       target: /dev/dri
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -33,6 +33,7 @@ services:
     - c 226:* rmw
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -43,5 +44,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-colibri-imx6.yml
+++ b/chromium/docker-compose-colibri-imx6.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/dri
       target: /dev/dri
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -42,4 +43,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-colibri-imx6ull.yml
+++ b/chromium/docker-compose-colibri-imx6ull.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -45,4 +46,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-colibri-imx6ull.yml
+++ b/chromium/docker-compose-colibri-imx6ull.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm/v7
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -36,6 +36,7 @@ services:
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     ipc: host
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -46,5 +47,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-colibri-imx7.yml
+++ b/chromium/docker-compose-colibri-imx7.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -45,4 +46,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-colibri-imx7.yml
+++ b/chromium/docker-compose-colibri-imx7.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm/v7
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -36,6 +36,7 @@ services:
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     ipc: host
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -46,5 +47,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/chromium/docker-compose-colibri-imx8x.yml
+++ b/chromium/docker-compose-colibri-imx8x.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 199:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm64
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -36,6 +36,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -46,5 +47,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-colibri-imx8x.yml
+++ b/chromium/docker-compose-colibri-imx8x.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -45,4 +46,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-verdin-am62.yml
+++ b/chromium/docker-compose-verdin-am62.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/dri
       target: /dev/dri
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -42,4 +43,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-verdin-am62.yml
+++ b/chromium/docker-compose-verdin-am62.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 226:* rmw
     image: torizon/chromium-am62@sha256:bb633a994129357eda8fef826ae614bbeadf99a8f9013ae1f2481c327c247433
+    platform: linux/arm64
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/dri
       target: /dev/dri
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -33,6 +33,7 @@ services:
     - c 226:* rmw
     image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -43,5 +44,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-verdin-imx8mm.yml
+++ b/chromium/docker-compose-verdin-imx8mm.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 199:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm64
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -36,6 +36,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -46,5 +47,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-verdin-imx8mm.yml
+++ b/chromium/docker-compose-verdin-imx8mm.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -45,4 +46,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-verdin-imx8mp.yml
+++ b/chromium/docker-compose-verdin-imx8mp.yml
@@ -8,6 +8,7 @@ services:
     device_cgroup_rules:
     - c 199:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
+    platform: linux/arm64
     security_opt:
     - seccomp:unconfined
     shm_size: 256mb
@@ -21,7 +22,6 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -36,6 +36,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -46,5 +47,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/chromium/docker-compose-verdin-imx8mp.yml
+++ b/chromium/docker-compose-verdin-imx8mp.yml
@@ -21,6 +21,7 @@ services:
     - source: /dev/
       target: /dev/
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -45,4 +46,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/codesys/docker-compose-apalis-imx6.yml
+++ b/codesys/docker-compose-apalis-imx6.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
+    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -69,4 +72,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-apalis-imx6.yml
+++ b/codesys/docker-compose-apalis-imx6.yml
@@ -7,6 +7,7 @@ services:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
-    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
+    platform: linux/arm/v7
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -67,10 +67,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-apalis-imx8.yml
+++ b/codesys/docker-compose-apalis-imx8.yml
@@ -7,6 +7,7 @@ services:
     - c 199:* rmw
     image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
-    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
+    platform: linux/arm64
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -68,10 +68,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-apalis-imx8.yml
+++ b/codesys/docker-compose-apalis-imx8.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
+    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -70,4 +73,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx6.yml
+++ b/codesys/docker-compose-colibri-imx6.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
+    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -69,4 +72,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx6.yml
+++ b/codesys/docker-compose-colibri-imx6.yml
@@ -7,6 +7,7 @@ services:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
-    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
+    platform: linux/arm/v7
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -67,10 +67,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx6ull.yml
+++ b/codesys/docker-compose-colibri-imx6ull.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
+    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -69,4 +72,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx6ull.yml
+++ b/codesys/docker-compose-colibri-imx6ull.yml
@@ -7,6 +7,7 @@ services:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
-    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
+    platform: linux/arm/v7
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -67,10 +67,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx7.yml
+++ b/codesys/docker-compose-colibri-imx7.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
+    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -69,4 +72,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx7.yml
+++ b/codesys/docker-compose-colibri-imx7.yml
@@ -7,6 +7,7 @@ services:
     - c 226:* rmw
     image: torizon/chromium@sha256:dfd33174d41d0b0b40fc456e076b7c4501ec480a5aad37e8cc2dc985db0673df
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/dri:/dev/dri
-    platform: "linux/arm/v7"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm@sha256:c8af14b752e4bf04482a1fa526f215d44e677b932394bacd4a98c2cfee68c771
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm/v7"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm32@sha256:10bb98626ed341ebcab3cf528419722943ad73ae3acc41921650de2c302a81de
     network_mode: host
     pid: host
+    platform: linux/arm/v7
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -67,10 +67,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm/v7"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx8x.yml
+++ b/codesys/docker-compose-colibri-imx8x.yml
@@ -7,6 +7,7 @@ services:
     - c 199:* rmw
     image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
-    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
+    platform: linux/arm64
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -68,10 +68,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-colibri-imx8x.yml
+++ b/codesys/docker-compose-colibri-imx8x.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
+    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -70,4 +73,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-verdin-am62.yml
+++ b/codesys/docker-compose-verdin-am62.yml
@@ -7,6 +7,7 @@ services:
     - c 199:* rmw
     image: torizon/chromium-am62@sha256:bb633a994129357eda8fef826ae614bbeadf99a8f9013ae1f2481c327c247433
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
-    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
+    platform: linux/arm64
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -68,10 +68,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-verdin-am62.yml
+++ b/codesys/docker-compose-verdin-am62.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
+    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -70,4 +73,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-verdin-imx8mm.yml
+++ b/codesys/docker-compose-verdin-imx8mm.yml
@@ -7,6 +7,7 @@ services:
     - c 199:* rmw
     image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
-    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
+    platform: linux/arm64
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -68,10 +68,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-verdin-imx8mm.yml
+++ b/codesys/docker-compose-verdin-imx8mm.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
+    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -70,4 +73,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-verdin-imx8mp.yml
+++ b/codesys/docker-compose-verdin-imx8mp.yml
@@ -7,6 +7,7 @@ services:
     - c 199:* rmw
     image: torizon/chromium@sha256:892f9c2c98414ea70d061f02c0837559f49c65a308e9bb8a987d8613c9bb07d8
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     security_opt:
     - seccomp=unconfined
@@ -15,7 +16,6 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
-    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -39,22 +39,22 @@ services:
     - codesys-setup
     image: toradexdemos/codesyscontrol_virtuallinuxarm64@sha256:b80d932ab312ba764d13493747690fb67e8238c68c0446c7ba2d1c862cf26b27
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount/conf/codesyscontrol/:/conf/codesyscontrol/:ro
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
-    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
     pid: host
+    platform: linux/arm64
     privileged: true
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -68,10 +68,10 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     restart: unless-stopped
     volumes:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
-    platform: "linux/arm64"
 version: '3.8'

--- a/codesys/docker-compose-verdin-imx8mp.yml
+++ b/codesys/docker-compose-verdin-imx8mp.yml
@@ -15,6 +15,7 @@ services:
     - /tmp:/tmp
     - /var/run/dbus:/var/run/dbus
     - /dev/galcore:/dev/galcore
+    platform: "linux/arm64"
   codesys:
     cap_add:
     - CHOWN
@@ -44,6 +45,7 @@ services:
     - /tmp/dockerMount/data/codesyscontrol/:/data/codesyscontrol/:ro
     - /tmp/dockerMount/extension/codesyscontrol/:/var/opt/codesysextension/:ro
     - /var/run/codesysextension/:/var/run/codesysextension/
+    platform: "linux/arm64"
   codesys-setup:
     image: toradexdemos/codesys_demo_arm64@sha256:c2eb20e79bec67902411ca35dbc2a81b8c950b894f72dd00f00b6006ca585d7b
     network_mode: host
@@ -52,6 +54,7 @@ services:
     restart: unless-stopped
     volumes:
     - /tmp/dockerMount:/dockerMount_copy
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -70,4 +73,5 @@ services:
     - /dev:/dev
     - /tmp:/tmp
     - /run/udev/:/run/udev/
+    platform: "linux/arm64"
 version: '3.8'

--- a/qt/docker-compose-apalis-imx6.yml
+++ b/qt/docker-compose-apalis-imx6.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -37,4 +38,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-apalis-imx6.yml
+++ b/qt/docker-compose-apalis-imx6.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -28,6 +28,7 @@ services:
     - c 226:* rmw
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -38,5 +39,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-apalis-imx8.yml
+++ b/qt/docker-compose-apalis-imx8.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -31,6 +31,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -41,5 +42,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-apalis-imx8.yml
+++ b/qt/docker-compose-apalis-imx8.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -40,4 +41,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx6.yml
+++ b/qt/docker-compose-colibri-imx6.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -37,4 +38,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx6.yml
+++ b/qt/docker-compose-colibri-imx6.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -28,6 +28,7 @@ services:
     - c 226:* rmw
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -38,5 +39,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx6ull.yml
+++ b/qt/docker-compose-colibri-imx6ull.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -31,6 +31,7 @@ services:
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     ipc: host
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -41,5 +42,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx6ull.yml
+++ b/qt/docker-compose-colibri-imx6ull.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -40,4 +41,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx7.yml
+++ b/qt/docker-compose-colibri-imx7.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template@sha256:2552de91c1d2055bc58d3476240a0af5be0fa81719991637ba1bb96152464c67
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -31,6 +31,7 @@ services:
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     ipc: host
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -41,5 +42,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx7.yml
+++ b/qt/docker-compose-colibri-imx7.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm/v7"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -40,4 +41,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx8x.yml
+++ b/qt/docker-compose-colibri-imx8x.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -31,6 +31,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -41,5 +42,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-colibri-imx8x.yml
+++ b/qt/docker-compose-colibri-imx8x.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -40,4 +41,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-verdin-am62.yml
+++ b/qt/docker-compose-verdin-am62.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template-am62@sha256:c6621cb326d468ad4a48e5c9296b04892ffbd291a05ac3c82940ce8b02da2a25
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -28,6 +28,7 @@ services:
     - c 226:* rmw
     image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -38,5 +39,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-verdin-am62.yml
+++ b/qt/docker-compose-verdin-am62.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -37,4 +38,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-verdin-imx8mm.yml
+++ b/qt/docker-compose-verdin-imx8mm.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -31,6 +31,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -41,5 +42,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-verdin-imx8mm.yml
+++ b/qt/docker-compose-verdin-imx8mm.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -40,4 +41,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-verdin-imx8mp.yml
+++ b/qt/docker-compose-verdin-imx8mp.yml
@@ -9,6 +9,7 @@ services:
     - c 199:* rmw
     - c 226:* rmw
     image: lucastor/cppqml-template-vivante@sha256:963f25920c1f13892ecb4f345356d9e8992d245a3d2e121d94131d44f5f98ae7
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -16,7 +17,6 @@ services:
     - source: /dev
       target: /dev
       type: bind
-    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -31,6 +31,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -41,5 +42,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3.9'

--- a/qt/docker-compose-verdin-imx8mp.yml
+++ b/qt/docker-compose-verdin-imx8mp.yml
@@ -16,6 +16,7 @@ services:
     - source: /dev
       target: /dev
       type: bind
+    platform: "linux/arm64"
   weston:
     cap_add:
     - CAP_SYS_TTY_CONFIG
@@ -40,4 +41,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3.9'

--- a/weston/docker-compose-apalis-imx6.yml
+++ b/weston/docker-compose-apalis-imx6.yml
@@ -20,4 +20,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-apalis-imx6.yml
+++ b/weston/docker-compose-apalis-imx6.yml
@@ -10,6 +10,7 @@ services:
     - c 226:* rmw
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -20,5 +21,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-apalis-imx8.yml
+++ b/weston/docker-compose-apalis-imx8.yml
@@ -13,6 +13,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -23,5 +24,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-apalis-imx8.yml
+++ b/weston/docker-compose-apalis-imx8.yml
@@ -23,4 +23,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-colibri-imx6.yml
+++ b/weston/docker-compose-colibri-imx6.yml
@@ -20,4 +20,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-colibri-imx6.yml
+++ b/weston/docker-compose-colibri-imx6.yml
@@ -10,6 +10,7 @@ services:
     - c 226:* rmw
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -20,5 +21,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-colibri-imx6ull.yml
+++ b/weston/docker-compose-colibri-imx6ull.yml
@@ -13,6 +13,7 @@ services:
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     ipc: host
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -23,5 +24,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-colibri-imx6ull.yml
+++ b/weston/docker-compose-colibri-imx6ull.yml
@@ -23,4 +23,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-colibri-imx7.yml
+++ b/weston/docker-compose-colibri-imx7.yml
@@ -13,6 +13,7 @@ services:
     image: torizon/weston@sha256:857f83d0f5b63fe2e7d6e0f07f6264f936c58588b1ab77391b0ed5c5965b2da5
     ipc: host
     network_mode: host
+    platform: linux/arm/v7
     volumes:
     - source: /tmp
       target: /tmp
@@ -23,5 +24,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-colibri-imx7.yml
+++ b/weston/docker-compose-colibri-imx7.yml
@@ -23,4 +23,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm/v7"
 version: '3'

--- a/weston/docker-compose-colibri-imx8x.yml
+++ b/weston/docker-compose-colibri-imx8x.yml
@@ -13,6 +13,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -23,5 +24,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-colibri-imx8x.yml
+++ b/weston/docker-compose-colibri-imx8x.yml
@@ -23,4 +23,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-verdin-am62.yml
+++ b/weston/docker-compose-verdin-am62.yml
@@ -20,4 +20,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-verdin-am62.yml
+++ b/weston/docker-compose-verdin-am62.yml
@@ -10,6 +10,7 @@ services:
     - c 226:* rmw
     image: torizon/weston-am62@sha256:ded14c38171722dd327ed8cea44310ad793e9e263451729701a99540fae27880
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -20,5 +21,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-verdin-imx8mm.yml
+++ b/weston/docker-compose-verdin-imx8mm.yml
@@ -13,6 +13,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -23,5 +24,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-verdin-imx8mm.yml
+++ b/weston/docker-compose-verdin-imx8mm.yml
@@ -23,4 +23,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-verdin-imx8mp.yml
+++ b/weston/docker-compose-verdin-imx8mp.yml
@@ -13,6 +13,7 @@ services:
     - ACCEPT_FSL_EULA=1
     image: torizon/weston-vivante@sha256:20b09290a5238b2b61d5f6965e2407347867100f488ce77cfd19f485d82501e6
     network_mode: host
+    platform: linux/arm64
     volumes:
     - source: /tmp
       target: /tmp
@@ -23,5 +24,4 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
-    platform: "linux/arm64"
 version: '3'

--- a/weston/docker-compose-verdin-imx8mp.yml
+++ b/weston/docker-compose-verdin-imx8mp.yml
@@ -23,4 +23,5 @@ services:
     - source: /run/udev
       target: /run/udev
       type: bind
+    platform: "linux/arm64"
 version: '3'


### PR DESCRIPTION
Any of the demo apps that are targeted at specific modules should declare the platform. Without this, there are issues when creating lockboxes.  When running torizoncore-builder to create a lockbox the tool will attempt to pull both 32- and 64- bit images which may not exist in all cases, notably the accelerated containers which are architecture specific.